### PR TITLE
Este/predictable size

### DIFF
--- a/k6/src/k6/send-messages.test.ts
+++ b/k6/src/k6/send-messages.test.ts
@@ -18,6 +18,7 @@ const amountOfReceivers = nodesData.nodes.filter(
 ).length;
 
 const MaxPayloadBytes = 400;
+// UTF-8 uses variying byte sizes - try to keep them in the single byte range
 const Alphabet =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 

--- a/k6/src/k6/send-messages.test.ts
+++ b/k6/src/k6/send-messages.test.ts
@@ -4,7 +4,6 @@ import { Counter, Trend } from "k6/metrics";
 import http, { RefinedParams, RefinedResponse, ResponseType } from "k6/http";
 import { check, fail } from "k6";
 import ws from "k6/ws";
-import crypto from 'k6/crypto';
 // 1. Begin Init section
 const nodes = __ENV.NODES || "many2many";
 
@@ -18,7 +17,9 @@ const amountOfReceivers = nodesData.nodes.filter(
     node.enabled && node.isReceiver != undefined && node.isReceiver,
 ).length;
 
-const MaxPayloadBytes = 325;
+const MaxPayloadBytes = 400;
+const Alphabet =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 // Override API Token
 if (__ENV.HOPRD_API_TOKEN) {
@@ -249,13 +250,12 @@ export function multipleHopMessage(dataPool: {
 
 function extendWrandomBytes(body: string): string {
   const count = MaxPayloadBytes - body.length - 1;
-  const bytes = crypto.randomBytes(count);
-  const uintArray = new Uint8Array(bytes);
-  const str = uintArray.reduce<string>((acc, v) => {
-    acc += String.fromCharCode(v);
-    return acc;
-  }, "");
-  return `${body} ${str}`;
+  let rndmContent = "";
+  for (let i = 0; i < count; i++) {
+    const idx = Math.floor(Math.random() * Alphabet.length);
+    rndmContent += Alphabet.charAt(idx);
+  }
+  return `${body} ${rndmContent}`;
 }
 
 export function teardown(dataPool: {

--- a/k6/src/k6/send-messages.test.ts
+++ b/k6/src/k6/send-messages.test.ts
@@ -18,7 +18,6 @@ const amountOfReceivers = nodesData.nodes.filter(
 ).length;
 
 const MaxPayloadBytes = 400;
-// UTF-8 uses variying byte sizes - try to keep them in the single byte range
 const Alphabet =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -249,6 +248,9 @@ export function multipleHopMessage(dataPool: {
   );
 }
 
+// use random ASCI chars to extend the payload
+// UTF-8 uses variying byte sizes - try to keep them in the single byte range
+// so we have a predicatble payload size
 function extendWrandomBytes(body: string): string {
   const count = MaxPayloadBytes - body.length - 1;
   let rndmContent = "";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased maximum payload size for messages to 400 bytes.
	- Introduced a new constant for generating random alphanumeric content.

- **Improvements**
	- Enhanced logic for payload extension to ensure predictable sizes.
	- Clarified handling of WebSocket message types and improved logging for unknown types.

- **Bug Fixes**
	- Retained error handling for WebSocket disconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->